### PR TITLE
Improve contrast in light mode

### DIFF
--- a/css/cv-style.css
+++ b/css/cv-style.css
@@ -219,6 +219,21 @@ h4.skills__item{
     padding-left: 10px;
 }
 
+[data-theme="dark"] .contact-me__item,
+[data-theme="dark"] .experience__item,
+[data-theme="dark"] .skills__item{
+    background: var(--background);
+    border: none;
+    border-radius: 15px;
+}
+
+[data-theme="dark"] .contact-me__item:hover,
+[data-theme="dark"] .experience__item:hover,
+[data-theme="dark"] .skills__item:hover{
+    background: var(--background-items);
+    padding-left: 10px;
+}
+
 
 nav, .navbar-container, .navbar-items{
     display: none;

--- a/css/drawing-design.css
+++ b/css/drawing-design.css
@@ -69,7 +69,7 @@ h6{
 .main-section__text{
     width: 100%;
     max-width: 720px;
-    color: #E7E7E7;
+    color: var(--not-black);
 }
 
 .drawing-section{
@@ -141,7 +141,7 @@ a{
 }
 
 .button>h4{
-    color: white;
+    color: var(--button-text);
     font-size: 1.8rem;
     text-decoration: none;
 }
@@ -259,7 +259,7 @@ a{
 
 
 .button__text{
-    color: white;
+    color: var(--button-text);
     font-size: 1.8rem;
     font-weight: 400;
 }

--- a/css/front-design.css
+++ b/css/front-design.css
@@ -131,7 +131,7 @@ a{
 }
 
 .button>h4{
-    color: white;
+    color: var(--button-text);
     font-size: 1.8rem;
     text-decoration: none;
 }
@@ -189,7 +189,7 @@ a{
 
 
 .button__text{
-    color: white;
+    color: var(--button-text);
     font-size: 1.8rem;
     font-weight: 400;
 }

--- a/css/general-styles.css
+++ b/css/general-styles.css
@@ -4,8 +4,8 @@
 
 
 :root{
-    --background: #f8f8f8;
-    --background-gradient: #f8f8f8;
+    --background: #ffffff;
+    --background-gradient: radial-gradient(30% 60% at 5% 10%, rgba(163, 106, 221, 0.3) 0%, rgba(255, 255, 255, 0) 60%), radial-gradient(60% 100% at 100% 90%, rgba(90, 150, 243, 0.3) 0%, rgba(255, 255, 255, 0) 70%), radial-gradient(80% 120% at 10% 20%, #ffffff 0%, #f8f8f8 100%);
     --background-items: linear-gradient(274.43deg, rgba(163, 106, 221, 0.1) 0%, rgba(90, 150, 243, 0.1) 100%);
     --primary-button--normal: linear-gradient(274.43deg, #A36ADD 0%, #5A96F3 100%);
     --primary-button--hover: #5A96F3;
@@ -13,6 +13,7 @@
     --secundary-button--hover:#202020;
     --not-black: #202020;
     --navbar-link-color: #202020;
+    --button-text: #000000;
     --border-card-color: #A36ADD26;
     font-family:'Lato', sans-serif;
 
@@ -26,6 +27,7 @@
     --background-gradient: radial-gradient(30% 60% at 5% 10%, #00134BFF 0%, #2F004AA8 43%, #00000000 100%),radial-gradient(60% 100% at 100% 90%, #1B103BFF 0%, #2B103BBA 22%, #06112F00 100%),radial-gradient(80% 120% at 10% 20%, #06112FFF 0%, #000000FF 100%);
     --navbar-link-color: #ffffff;
     --not-black: #e7e7e7;
+    --button-text: #ffffff;
 }
 
 *{
@@ -33,6 +35,11 @@
     padding: 0;
     box-sizing: border-box;
     font-size: 64.5%;
+}
+
+body{
+    color: var(--not-black);
+    background: var(--background);
 }
 
 .main-title__color{

--- a/css/landing-style.css
+++ b/css/landing-style.css
@@ -6,7 +6,13 @@ body{
     height: 100vh;
     display: grid;
     place-content: center;
+    
+}
 
+.landing-toggle{
+    position: fixed;
+    top: 20px;
+    right: 20px;
 }
 
 .container, .title, .profile, .profile__work, .profile__cv, .contact, .container__main-content{
@@ -45,7 +51,7 @@ body{
     text-align: center;
     font-weight: 400;
     text-decoration: none;
-    color: #fafafa;
+    color: var(--not-black);
 }
 
 .title__job>b{
@@ -100,14 +106,15 @@ a{
     text-decoration: none;
 }
 
+
 .button>a{
-    color: white;
+    color: var(--button-text);
     font-size: 1.8rem;
     text-decoration: none;
 }
 
 .button__text{
-    color: white;
+    color: var(--button-text);
     font-size: 1.8rem;
     font-weight: 400;
 }
@@ -115,7 +122,7 @@ a{
 
 .contact>p, .contact>p>b{
     font-size: 1.5rem;
-    color: #fafafa;
+    color: var(--not-black);
 }
 
 @media (min-width:720px){
@@ -143,7 +150,7 @@ a{
         gap: 5px;
         position: absolute;
         bottom: 10%;
-        color: #fafafa;
+        color: var(--not-black);
     }
 
     .contact>p, .contact>p>b{
@@ -156,7 +163,7 @@ a{
         text-align: left;
         font-weight: 400;
         text-decoration: none;
-        color: #fafafa;
+        color: var(--not-black);
     }
 
     .title{

--- a/css/ui-design.css
+++ b/css/ui-design.css
@@ -20,7 +20,7 @@ h2{
 }
 
 h3{
-    color: #FFF ;
+    color: var(--not-black);
     font-size: 3.2rem;
     font-style: normal;
     line-height: 100%;
@@ -32,14 +32,13 @@ h6,p{
     
 }
 
-p{  
-    color: #C7C7C7; 
+p{
+    color: var(--not-black);
     font-family: "Inter", sans-serif;
     font-size: 1.6rem;
     font-style: normal;
     font-weight: 400;
     line-height: 150%;
-    color: #C7C7C7;
 }
 
 h6{
@@ -124,11 +123,11 @@ nav{
     font-style: normal;
     font-weight: 300;
     line-height: 3.2rem; /* 160% */
-    color: #fafafa;
+    color: var(--not-black);
 }
 
 .main-section__text>h6:nth-child(4){
-    color: #A4A7AC;
+    color: var(--not-black);
 }
 
 .designs-section{
@@ -144,7 +143,7 @@ nav{
     max-width: 920px;
     align-items: center;
     gap: 56px;
-    color: #C7C7C7;
+    color: var(--not-black);
 }
 
 .card>img{
@@ -221,7 +220,7 @@ nav{
 }
 
 .text-wip{
-    color: #A4A7AC;
+    color: var(--not-black);
 }
 
 @media (max-width: 480px){

--- a/cv.html
+++ b/cv.html
@@ -23,9 +23,7 @@
                 <a href="./ui-design.html">Diseño</a>
                 <a href="./drawing-design.html">Dibujos</a>
                 <button class="button-icon" id="themeToggle" aria-label="Cambiar tema">
-                    <svg id="themeToggleIcon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
-                        <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/>
-                    </svg>
+                    <span id="themeToggleIcon"></span>
                 </button>
             </div>
         </nav>

--- a/drawing-design.html
+++ b/drawing-design.html
@@ -25,9 +25,7 @@
                         <h4>Curriculum</h4>
                     </a>
                     <button class="button-icon" id="themeToggle" aria-label="Cambiar tema">
-                        <svg id="themeToggleIcon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
-                            <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/>
-                        </svg>
+                        <span id="themeToggleIcon"></span>
                     </button>
                 </div>
             </nav>

--- a/index.html
+++ b/index.html
@@ -12,6 +12,9 @@
 </head>
 
 <body>
+    <button class="button-icon landing-toggle" id="themeToggle" aria-label="Cambiar tema">
+        <span id="themeToggleIcon"></span>
+    </button>
     <div class="container">
         <div class="container__main-content">
             <div class="title">
@@ -44,6 +47,7 @@
             <p>El diseño y desarrollo de este sitio web es hecho por mi</p>
         </div>
     </div>
+    <script src="js/theme-toggle.js"></script>
 </body>
 
 </html>

--- a/js/theme-toggle.js
+++ b/js/theme-toggle.js
@@ -3,7 +3,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const icon = document.getElementById('themeToggleIcon');
   if (!btn || !icon) return;
 
-  const sunSVG = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2v2m0 16v2m9-9h-2M5 12H3m15.364-6.364l-1.414 1.414M6.05 17.95l-1.414 1.414M18.364 17.95l-1.414-1.414M6.05 6.05L4.636 4.636M12 7a5 5 0 100 10 5 5 0 000-10z"/></svg>';
+  const sunSVG = '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M12 2v2m0 16v2m9-9h-2M5 12H3m15.364-6.364l-1.414 1.414M6.05 17.95l-1.414 1.414M18.364 17.95l-1.414-1.414M6.05 6.05L4.636 4.636M12 7a5 5 0 100 10 5 5 0 000-10z"/></svg>';
   const moonSVG = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>';
 
   function setIcon(theme){

--- a/ui-design.html
+++ b/ui-design.html
@@ -24,9 +24,7 @@
                         <h4>Curriculum</h4>
                     </a>
                     <button class="button-icon" id="themeToggle" aria-label="Cambiar tema">
-                        <svg id="themeToggleIcon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
-                            <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/>
-                        </svg>
+                        <span id="themeToggleIcon"></span>
                     </button>
                 </div>
             </nav>


### PR DESCRIPTION
## Summary
- use new `--button-text` variable for buttons
- switch grey text to `--not-black` for AAA contrast
- update light theme contrast across pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ef269f23c832e98472fd0b18b9db9