### PR TITLE
Apply style improvements and cleanup CV page

### DIFF
--- a/css/cv-style.css
+++ b/css/cv-style.css
@@ -1,7 +1,9 @@
 @import url('https://fonts.googleapis.com/css2?family=Jaldi:wght@700&family=Lato:wght@300;400;700&display=swap');
 
 body{
-    background: var(--background);
+    background-size: 100% 100%;
+    background-position: 0px 0px,0px 0px,0px 0px;
+    background-image: var(--background-gradient);
     width: 100vw;
     height: 100vh;
     display: grid;
@@ -338,6 +340,10 @@ nav{
   ::-webkit-scrollbar-track {
     background: #e4e4e4;
     border-radius: 5px;
+  }
+
+  [data-theme="dark"] ::-webkit-scrollbar-track {
+    background: #333333;
   }
    
   ::-webkit-scrollbar-thumb {

--- a/css/drawing-design.css
+++ b/css/drawing-design.css
@@ -264,6 +264,10 @@ a{
     font-weight: 400;
 }
 
+.button--social-media .button__text{
+    color: #F8F8F8;
+}
+
 
 
 

--- a/css/front-design.css
+++ b/css/front-design.css
@@ -1,12 +1,14 @@
 body{
-    background: var(--background);
+    background-size: 100% 100%;
+    background-position: 0px 0px,0px 0px,0px 0px;
+    background-image: var(--background-gradient);
     width: 100vw;
     height: 100vh;
     display: flex;
     justify-content: center;
     align-content: flex-start;
     padding-top: 50px;
-    
+
 }
 
 h2,h3{

--- a/css/general-styles.css
+++ b/css/general-styles.css
@@ -67,3 +67,10 @@ body{
     fill: currentColor;
 }
 
+.navbar-container{
+    position: sticky;
+    top: 0;
+    background: var(--background);
+    z-index: 1000;
+}
+

--- a/css/landing-style.css
+++ b/css/landing-style.css
@@ -119,6 +119,10 @@ a{
     font-weight: 400;
 }
 
+.profile__cv .button__text{
+    color: #ffffff;
+}
+
 
 .contact>p, .contact>p>b{
     font-size: 1.5rem;

--- a/css/wip.css
+++ b/css/wip.css
@@ -1,5 +1,7 @@
 body{
-    background: var(--background);
+    background-size: 100% 100%;
+    background-position: 0px 0px,0px 0px,0px 0px;
+    background-image: var(--background-gradient);
     width: 100vw;
     height: 100vh;
     display: grid;

--- a/cv.html
+++ b/cv.html
@@ -72,84 +72,84 @@
             <div class="section">
                 <h3 class="section__title">Mi experiencia laboral</h3>
                 <div class="group">
-                    <a href="https://www.linkedin.com/in/jose-silvaart" class="experience__item" target="_blank">
+                    <div class="experience__item">
                         <img src="img/multiplica.png"></img>
                         <h4 class="my-work__item"><b>Diseñador UI - Senior</b><br>Multiplica<br>(07/2022 > 06/2024)</h4>
-                    </a>
-                    <a href="https://www.linkedin.com/in/jose-silvaart" class="experience__item" target="_blank">
+                    </div>
+                    <div class="experience__item">
                         <img src="img/genesys.png"></img>
                         <h4 class="my-work__item"><b>Diseñador UI - Senior</b><br>Genesys -> IBM<br>(01/2022 > 07/2022)</h4>
-                    </a>
-                    <a href="https://www.linkedin.com/in/jose-silvaart" class="experience__item" target="_blank">
+                    </div>
+                    <div class="experience__item">
                         <img src="img/goplaceit.png"></img>
                         <h4 class="my-work__item"><b>Diseñador UI - Semi Senior</b><br>Goplaceit<br>(12/2020 > 01/2022)</h4>
-                    </a>
-                    <a href="https://www.linkedin.com/in/jose-silvaart" class="experience__item" target="_blank">
+                    </div>
+                    <div class="experience__item">
                         <img src="img/trazar.png"></img>
                         <h4 class="my-work__item"><b>Diseñador gráfico - Senior</b><br>Trazar<br>(11/2018 > 04/2020)</h4>
-                    </a>
+                    </div>
                 </div>
             </div>
 
             <div class="section">
                 <h3 class="section__title">Mis habilidades</h3>
                 <div class="group">
-                    <a href="https://www.linkedin.com/in/jose-silvaart" class="skills__item" target="_blank">
+                    <div class="skills__item">
                         <img src="img/check-skills.svg"></img>
                         <h4>Empatía</h4>
-                    </a>
-                    <a href="https://www.linkedin.com/in/jose-silvaart" class="skills__item" target="_blank">
+                    </div>
+                    <div class="skills__item">
                         <img src="img/check-skills.svg"></img>
                         <h4>Liderazgo</h4>
-                    </a>
-                    <a href="https://www.linkedin.com/in/jose-silvaart" class="skills__item" target="_blank">
+                    </div>
+                    <div class="skills__item">
                         <img src="img/check-skills.svg"></img>
                         <h4>Colaboración y trabajo en equipo</h4>
-                    </a>
-                    <a href="https://www.linkedin.com/in/jose-silvaart" class="skills__item" target="_blank">
+                    </div>
+                    <div class="skills__item">
                         <img src="img/check-skills.svg"></img>
                         <h4>Proactivo y autodidacta</h4>
-                    </a>
-                    <a href="https://www.linkedin.com/in/jose-silvaart" class="skills__item" target="_blank">
+                    </div>
+                    <div class="skills__item">
                         <img src="img/check-skills.svg"></img>
                         <h4>Organización</h4>
-                    </a>
-                    <a href="https://www.linkedin.com/in/jose-silvaart" class="skills__item" target="_blank">
+                    </div>
+                    <div class="skills__item">
                         <img src="img/check-skills.svg"></img>
                         <h4>Metódico y ordenado</h4>
-                    </a>
-                    <a href="https://www.linkedin.com/in/jose-silvaart" class="skills__item" target="_blank">
+                    </div>
+                    <div class="skills__item">
                         <img src="img/check-skills.svg"></img>
                         <h4>Facilidad para enseñar</h4>
-                    </a>
-                    <a href="https://www.linkedin.com/in/jose-silvaart" class="skills__item" target="_blank">
+                    </div>
+                    <div class="skills__item">
                         <img src="img/check-skills.svg"></img>
                         <h4>Figma Avanzado</h4>
-                    </a>
-                    <a href="https://www.linkedin.com/in/jose-silvaart" class="skills__item" target="_blank">
+                    </div>
+                    <div class="skills__item">
                         <img src="img/check-skills.svg"></img>
                         <h4>Perfect Pixel</h4>
-                    </a>
-                    <a href="https://www.linkedin.com/in/jose-silvaart" class="skills__item" target="_blank">
+                    </div>
+                    <div class="skills__item">
                         <img src="img/check-skills.svg"></img>
                         <h4>Diseño de componentes</h4>
-                    </a>
-                    <a href="https://www.linkedin.com/in/jose-silvaart" class="skills__item" target="_blank">
+                    </div>
+                    <div class="skills__item">
                         <img src="img/check-skills.svg"></img>
                         <h4>Scrum</h4>
-                    </a>
-                    <a href="https://www.linkedin.com/in/jose-silvaart" class="skills__item" target="_blank">
+                    </div>
+                    <div class="skills__item">
                         <img src="img/check-skills.svg"></img>
                         <h4>Azure / Jira</h4>
-                    </a>
-                    <a href="https://www.linkedin.com/in/jose-silvaart" class="skills__item" target="_blank">
+                    </div>
+                    <div class="skills__item">
                         <img src="img/check-skills.svg"></img>
                         <h4>Entendimiento de GIT</h4>
-                    </a>
-                    <a href="https://www.linkedin.com/in/jose-silvaart" class="skills__item" target="_blank">
+                    </div>
+                    <div class="skills__item">
                         <img src="img/check-skills.svg"></img>
                         <h4>HTML, CSS3 y Javascript</h4>
-                    </a>
+                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
- tune contrast on drawing page social buttons
- make sticky nav bar across pages
- update homepage CV button text color
- dark-mode scrollbar for CV page
- use gradient background everywhere
- remove links from CV skills and experience sections

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684efbe88dc0832e9bbc94b16e2ad091