### PR TITLE
Update navbar layout and unify page containers

### DIFF
--- a/css/cv-style.css
+++ b/css/cv-style.css
@@ -20,7 +20,9 @@ body{
 .cv-container{
     padding: 30px 10px;
     gap: 60px;
-    max-width: 400px;
+    width: 100%;
+    max-width: 960px;
+    margin: 0 auto;
 }
 
 h3{
@@ -284,7 +286,7 @@ nav{
         flex-direction: row;
         gap: 80px;
         align-items: center;
-        max-width: 865px;
+        max-width: 960px;
         height: 600px;
         overflow: hidden;
         padding: 0;

--- a/css/drawing-design.css
+++ b/css/drawing-design.css
@@ -51,8 +51,9 @@ h6{
 .container, .main-section, .front-section, .designs-section__description{
     display: flex;
     flex-direction: column;
-    width: auto;
-    max-width: 100%;
+    width: 100%;
+    max-width: 960px;
+    margin: 0 auto;
     align-items: flex-start;
 }
 

--- a/css/front-design.css
+++ b/css/front-design.css
@@ -50,8 +50,9 @@ h6{
 .container, .main-section, .front-section, .designs-section__description, .card{
     display: flex;
     flex-direction: column;
-    width: auto;
-    max-width: 100%;
+    width: 100%;
+    max-width: 960px;
+    margin: 0 auto;
     align-items: flex-start;
 }
 

--- a/css/general-styles.css
+++ b/css/general-styles.css
@@ -67,6 +67,14 @@ body{
     fill: currentColor;
 }
 
+.page-container{
+    width: 100%;
+    max-width: 960px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+}
+
 .navbar-container{
     position: sticky;
     top: 0;

--- a/css/ui-design.css
+++ b/css/ui-design.css
@@ -64,6 +64,8 @@ h6>b{
     flex-direction: column;
     gap: 240px;
     width: 100%;
+    max-width: 960px;
+    margin: 0 auto;
     padding: 8.0rem 1rem;
     overflow-y: scroll;
     align-items: center;

--- a/cv.html
+++ b/cv.html
@@ -13,6 +13,7 @@
 
 </head>
 <body>
+    <div class="container page-container">
     <div class="navbar-container">
         <nav>
             <a href="./index.html">
@@ -184,6 +185,7 @@
             </div>
         </div>
 
+    </div>
     </div>
     <script src="js/theme-toggle.js"></script>
 </body>

--- a/drawing-design.html
+++ b/drawing-design.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="css/drawing-design.css">
 </head>
 <body>
-    <div class="container">
+    <div class="container page-container">
 
         <div class="navbar-container">
             <nav>

--- a/front-design.html
+++ b/front-design.html
@@ -28,7 +28,7 @@
             </div>
         </nav>
     </div>
-    <div class="container">
+    <div class="container page-container">
         <div class="main-section">
             <a href="http://josesilva.cl">
                 <img src="img/icon__arrow-left.svg" alt="">

--- a/index.html
+++ b/index.html
@@ -18,11 +18,6 @@
                 <img src="img/LogoJoseSilva.svg" alt="">
             </a>
             <div class="navbar-items">
-                <a href="./index.html">Inicio</a>
-                <a href="./ui-design.html">Diseño</a>
-                <a href="./cv.html" class="read-it">
-                    <h4>Curriculum</h4>
-                </a>
                 <button class="button-icon" id="themeToggle" aria-label="Cambiar tema">
                     <span id="themeToggleIcon"></span>
                 </button>

--- a/ui-design.html
+++ b/ui-design.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="css/ui-design.css">
 </head>
 <body>
-    <div class="container">
+    <div class="container page-container">
         <div class="navbar-container">
             <nav>
                 <a href="./index.html">


### PR DESCRIPTION
## Summary
- make landing page navbar only show theme toggle
- wrap drawing, UI, front and CV pages with `page-container`
- adjust nav wrappers on CV page
- enforce `max-width: 960px` for containers
- add `.page-container` base style

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f091c1d58832e9c055878db71a232