### PR TITLE
Improve home header layout

### DIFF
--- a/css/landing-style.css
+++ b/css/landing-style.css
@@ -6,7 +6,22 @@ body{
     height: 100vh;
     display: grid;
     place-content: center;
-    
+
+}
+
+/* Keep header fixed to the top on home page */
+body.home #navbar{
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    z-index: 1000;
+}
+
+/* Make the navbar span the full width so the toggle is flush right */
+body.home nav{
+    max-width: none;
+    padding: 0 20px;
 }
 
 .landing-toggle{
@@ -132,6 +147,10 @@ a{
 /* Hide navbar links on home page */
 body.home .navbar-items a{
     display: none;
+}
+body.home .navbar-items{
+    flex-grow: 1;
+    justify-content: flex-end;
 }
 
 @media (min-width:720px){


### PR DESCRIPTION
## Summary
- keep header fixed at the top of the home page
- make navbar span full width and align toggle to the right

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684f1e703a1c832ea5dac990127a01c6