### PR TITLE
Fix navbar toggle button width

### DIFF
--- a/css/general-styles.css
+++ b/css/general-styles.css
@@ -59,6 +59,7 @@ body{
     place-content: center;
     padding: 4px;
     color: var(--navbar-link-color);
+    width: 48px;
 }
 
 .button-icon svg{

--- a/front-design.html
+++ b/front-design.html
@@ -11,8 +11,8 @@
     <link rel="stylesheet" href="css/front-design.css">
 </head>
 <body>
-    <header id="navbar" class="navbar-container"></header>
     <div class="container page-container">
+        <header id="navbar" class="navbar-container" data-current="./ui-design.html"></header>
         <div class="main-section">
             <a href="http://josesilva.cl">
                 <img src="img/icon__arrow-left.svg" alt="">


### PR DESCRIPTION
## Summary
- tweak `.button-icon` style so the navbar theme toggle has a width of 48px
- include navbar inside `front-design.html` page container for consistent behavior

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684f279b2a50832ea8895d141f1e304a